### PR TITLE
Remove stripes propType

### DIFF
--- a/src/components/ViewAuditData.js
+++ b/src/components/ViewAuditData.js
@@ -56,14 +56,6 @@ class ViewAuditData extends React.Component {
 }
 
 ViewAuditData.propTypes = {
-  stripes: PropTypes.shape({
-    connect: PropTypes.func.isRequired,
-    locale: PropTypes.string.isRequired,
-    logger: PropTypes.object.isRequired,
-    intl: PropTypes.shape({
-      formatMessage: PropTypes.func.isRequired,
-    }),
-  }).isRequired,
   resources: PropTypes.shape({
     selectedInstance: PropTypes.shape({
       records: PropTypes.arrayOf(PropTypes.object),


### PR DESCRIPTION
When searching around the `folio-org` for use of the deprecated `stripes.intl.formatMessage()`, I found this unused propType declaration.